### PR TITLE
Make profiling work as a normal user.

### DIFF
--- a/performance-tests/perf-tests.sh
+++ b/performance-tests/perf-tests.sh
@@ -96,7 +96,6 @@ setupAsyncProfilerKroxy() {
 
   mkdir -p "${LOADER_DIR}"
   unzip -o -q /tmp/asprof/ap-loader-all.jar -d "${LOADER_DIR}"
-  chmod -R +rw "${LOADER_DIR}"
 }
 
 deleteAsyncProfilerKroxy() {
@@ -117,7 +116,7 @@ startAsyncProfilerKroxy() {
 
   echo "TARGETARCH: ${TARGETARCH}"
 
-  ${CONTAINER_ENGINE} exec -it ${KROXYLICIOUS_CONTAINER_ID} mkdir -p "${LOADER_DIR}/"{bin,libs,lib} && chmod +r -R "${LOADER_DIR}"
+  ${CONTAINER_ENGINE} exec -it ${KROXYLICIOUS_CONTAINER_ID} mkdir -p "${LOADER_DIR}/lib" && chmod +r -R "${LOADER_DIR}"
   ${CONTAINER_ENGINE} cp "${LOADER_DIR}/libs/libasyncProfiler-3.0-${TARGETARCH}.so" "${KROXYLICIOUS_CONTAINER_ID}:${LOADER_DIR}/lib/libasyncProfiler.so"
 
   java -Dap_loader_extraction_dir=${LOADER_DIR} -jar /tmp/asprof/ap-loader-all.jar profiler start "${KROXYLICIOUS_PID}"

--- a/performance-tests/perf-tests.sh
+++ b/performance-tests/perf-tests.sh
@@ -116,7 +116,7 @@ startAsyncProfilerKroxy() {
 
   echo "TARGETARCH: ${TARGETARCH}"
 
-  ${CONTAINER_ENGINE} exec -it ${KROXYLICIOUS_CONTAINER_ID} mkdir -p "${LOADER_DIR}/lib" && chmod +r -R "${LOADER_DIR}"
+  ${CONTAINER_ENGINE} exec -it ${KROXYLICIOUS_CONTAINER_ID} mkdir -p "${LOADER_DIR}/""{bin,lib}" && chmod +r -R "${LOADER_DIR}"
   ${CONTAINER_ENGINE} cp "${LOADER_DIR}/libs/libasyncProfiler-3.0-${TARGETARCH}.so" "${KROXYLICIOUS_CONTAINER_ID}:${LOADER_DIR}/lib/libasyncProfiler.so"
 
   java -Dap_loader_extraction_dir=${LOADER_DIR} -jar /tmp/asprof/ap-loader-all.jar profiler start "${KROXYLICIOUS_PID}"


### PR DESCRIPTION
### Type of change

- Bugfix

### Description

Leverage the `ap_loader_extraction_dir` [system property](https://github.com/jvm-profiling-tools/ap-loader/blob/ce29b5b6d4356dae914dc4fdb4fd418297c46c7a/src/main/java/one/profiler/AsyncProfilerLoader.java#L52) to avoid messing around with user specific paths. Its all still rather fiddly and annoying but it now works for me.

### Additional Context

_Why are you making this pull request?_

### Checklist

_Please go through this checklist and make sure all applicable tasks have been done_

- [ ] Write tests
- [ ] Make sure all tests pass
- [ ] Review performance test results. Ensure that any degradations to performance numbers are understood and justified.
- [ ] Make sure all Sonarcloud warnings are addressed or are justifiably ignored.
- [ ] Update documentation
- [ ] Reference relevant issue(s) and close them after merging
- [ ] For user facing changes, update CHANGELOG.md (remember to include changes affecting the API of the test artefacts too).
